### PR TITLE
Support select camera type by entry attribute

### DIFF
--- a/examples/MJPEG_camera.py
+++ b/examples/MJPEG_camera.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     camera_stream = "192.168.1.26:80"
 
     # Create the Camera instance
-    camera = nano.Camera(camera_type=3, source=camera_stream, width=640, height=480, fps=30)
+    camera = nano.Camera(camera_type=nano.MJPEG, source=camera_stream, width=640, height=480, fps=30)
     print('MJPEG/IP Camera is now ready')
     while True:
         try:

--- a/examples/RTSP_camera.py
+++ b/examples/RTSP_camera.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     # a location for the rtsp stream
     rtsp_location = "192.168.1.26:8554/stream"
     # Create the Camera instance
-    camera = nano.Camera(camera_type=2, source=rtsp_location, width=640, height=480, fps=30)
+    camera = nano.Camera(camera_type=nano.RTSP, source=rtsp_location, width=640, height=480, fps=30)
     print('RTSP Camera is now ready')
     while True:
         try:

--- a/examples/USB_camera.py
+++ b/examples/USB_camera.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     # for usb camera /dev/video2, the device_id will be 2
 
     # Create the Camera instance
-    camera = nano.Camera(camera_type=1, device_id=1, width=640, height=480, fps=30)
+    camera = nano.Camera(camera_type=nano.USB, device_id=1, width=640, height=480, fps=30)
     print('USB Camera is now ready')
     while True:
         try:

--- a/examples/USB_camera_with_debug.py
+++ b/examples/USB_camera_with_debug.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
 	try:
 		# Create the Camera instance
 		print("camera stream")
-		camera = nano.Camera(camera_type=1, device_id=0, width=640, height=480, fps=30, debug=True)
+		camera = nano.Camera(camera_type=nano.USB, device_id=0, width=640, height=480, fps=30, debug=True)
 	except Exception as e:
 		print("Exception occurred ------ ")
 		print("Exception Type - ", e)

--- a/nanocamera/NanoCam.py
+++ b/nanocamera/NanoCam.py
@@ -5,8 +5,14 @@ from threading import Thread
 import cv2
 
 
+CSI: int = 0
+USB: int = 1
+RTSP: int = 2
+MJPEG: int = 3 
+
+
 class Camera:
-    def __init__(self, camera_type=0, device_id=0, source="localhost:8080", flip=0, width=640, height=480, fps=30,
+    def __init__(self, camera_type=CSI, device_id=0, source="localhost:8080", flip=0, width=640, height=480, fps=30,
                  enforce_fps=False, debug=False):
         # initialize all variables
         self.fps = fps
@@ -117,18 +123,20 @@ class Camera:
     def open(self):
         # open the camera inteface
         # determine what type of camera to open
-        if self.camera_type == 0:
+        if self.camera_type == CSI:
             # then CSI camera
             self.__open_csi()
-        elif self.camera_type == 2:
+        elif self.camera_type == USB:
+            # it is USB camera
+            self.__open_usb()
+        elif self.camera_type == RTSP:
             # rtsp camera
             self.__open_rtsp()
-        elif self.camera_type == 3:
+        elif self.camera_type == MJPEG:
             # http camera
             self.__open_mjpeg()
         else:
-            # it is USB camera
-            self.__open_usb()
+            raise Exception("Not Support Camera Type %d", self.camera_type)
         return self
 
     def start(self):

--- a/nanocamera/__init__.py
+++ b/nanocamera/__init__.py
@@ -1,1 +1,2 @@
 from nanocamera.NanoCam import Camera
+from nanocamera.NanoCam import CSI, USB, RTSP, MJPEG


### PR DESCRIPTION
Make NanoCamera easier to use. Selecting camera type by entry attribute. Example: nano.USB, it means it named.